### PR TITLE
Readonly mode

### DIFF
--- a/output_viewer/build.py
+++ b/output_viewer/build.py
@@ -85,4 +85,5 @@ def build_viewer(index_path="index.json", diag_name="Output Viewer", default_mas
 
     shutil.copytree(static_dir, viewer_dir)
 
-    rechmod(viewer_dir)
+    if default_mask is not None:
+        rechmod(viewer_dir, default_mask)

--- a/output_viewer/build.py
+++ b/output_viewer/build.py
@@ -6,9 +6,11 @@ from page import Page
 from collections import OrderedDict
 import datetime
 import os
+import stat
+from utils import rechmod
 
 
-def build_viewer(index_path="index.json", diag_name="Output Viewer"):
+def build_viewer(index_path="index.json", diag_name="Output Viewer", default_mask=None):
     try:
         with open(index_path) as index_file:
             spec = json.load(index_file)
@@ -38,9 +40,10 @@ def build_viewer(index_path="index.json", diag_name="Output Viewer"):
     spec = spec["specification"]
 
     path = os.path.dirname(index_path)
+
     pages = []
     for ind, plotspec in enumerate(spec):
-        page = Page(plotspec, root_path=path)
+        page = Page(plotspec, root_path=path, permissions=default_mask)
         page_name = page.short_name if page.short_name else "set_%d" % (ind + 1)
         pages.append((page, page_name))
 
@@ -58,6 +61,7 @@ def build_viewer(index_path="index.json", diag_name="Output Viewer"):
     grid = col.append_tag('div', class_="img_links")
     table.append_header().append_cell("Output Sets")
     icons = []
+
     for page, page_name in pages:
         page.build(page_name, toolbar)
         page_path = os.path.join(page_name, "index.html")
@@ -71,10 +75,14 @@ def build_viewer(index_path="index.json", diag_name="Output Viewer"):
     with open(os.path.join(path, "index.html"), "w") as f:
         toolbar.setLevel(0)
         f.write(doc.build())
+        os.chmod(os.path.join(path, "index.html"), default_mask)
 
     static_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), "static")
-
     viewer_dir = os.path.join(path, "viewer")
+
     if os.path.exists(viewer_dir):
         shutil.rmtree(viewer_dir)
+
     shutil.copytree(static_dir, viewer_dir)
+
+    rechmod(viewer_dir)

--- a/output_viewer/page.py
+++ b/output_viewer/page.py
@@ -1,7 +1,7 @@
 from .htmlbuilder import Document, Table, TableCell, Link, Span
 import os
 from .examine import is_img, is_data
-from .utils import slugify, nuke_and_pave
+from .utils import slugify, nuke_and_pave, rechmod
 
 
 class Column(object):
@@ -103,12 +103,13 @@ class Group(object):
 
     def build(self, toolbar):
         nuke_and_pave(self.dirpath)
+
         for r in self.rows:
             r.build(toolbar)
 
 
 class Page(object):
-    def __init__(self, spec, root_path="./"):
+    def __init__(self, spec, root_path="./", permissions=None):
         self.name = spec.get("title", "")
         self.short_name = spec.get("short_name", None)
 
@@ -127,6 +128,7 @@ class Page(object):
                 self.number_of_cols = max(len(g["columns"]), self.number_of_cols)
                 self.groups.append(g)
         self.root_path = root_path
+        self.permissions = permissions
         self.description = spec.get("description", "")
         self.icon = spec.get("icon", None)
         self.rows = spec.get("rows", [])
@@ -200,4 +202,8 @@ class Page(object):
         with open(os.path.join(self.root_path, dirname, "index.html"), "w") as outfile:
             if toolbar is not None:
                 toolbar.setLevel(1)
+
             outfile.write(doc.build())
+
+        if self.permissions is not None:
+            rechmod(os.path.join(self.root_path, dirname), self.permissions)

--- a/output_viewer/utils.py
+++ b/output_viewer/utils.py
@@ -21,6 +21,7 @@ def nuke_and_pave(path):
 
 
 def rechmod(path, perms):
+    os.chmod(path, perms)
     for path, dirs, files in os.walk(path):
         for f in [os.path.join(path, f) for f in files]:
             os.chmod(f, perms)

--- a/output_viewer/utils.py
+++ b/output_viewer/utils.py
@@ -18,3 +18,11 @@ def nuke_and_pave(path):
     if os.path.exists(path):
         shutil.rmtree(path)
     os.mkdir(path)
+
+
+def rechmod(path, perms):
+    for path, dirs, files in os.walk(path):
+        for f in [os.path.join(path, f) for f in files]:
+            os.chmod(f, perms)
+        for d in [os.path.join(path, d) for d in dirs]:
+            os.chmod(d, perms)


### PR DESCRIPTION
Adds permission management functionality (for annoying installs where default permissions exist) where the user can specify what permissions to use for the viewer folder.
