### PR TITLE
Updates output_viewer

### DIFF
--- a/output_viewer/diagsviewer.py
+++ b/output_viewer/diagsviewer.py
@@ -61,6 +61,7 @@ class DiagnosticsViewerClient(object):
         return ds_id
 
     def upload_files(self, dataset, files):
+        os.chdir('..')
         files_remaining = list(files)
         s = requests.Session()
         ds_id = None


### PR DESCRIPTION
I had an issue where the diag viewer would fail to recognize the package correctly, and fail to upload even though everything was in the right place. Turns out it chdirs to the target directory (/something/something/amwg/) and then tries to upload the files 'amwg/FILE', which doesnt work because its already in the amwg directory. By moving up a directory, it works.
