### PR TITLE
Fix file path by converting bytes to str

### DIFF
--- a/output_viewer/utils.py
+++ b/output_viewer/utils.py
@@ -10,6 +10,7 @@ def slugify(value):
     and converts spaces to hyphens.
     """
     value = unicodedata.normalize('NFKD', value).encode('ascii', 'ignore')
+    value = value.decode('utf-8')
     value = str(re.sub('[^\w\s-]', '', str(value)).strip().lower())
     return re.sub('[-\s]+', '-', str(value))
 


### PR DESCRIPTION
File paths included a leading 'b' because `bytes` objects were not included. For example we had the URL `viewer/taylor/bsummary-taylor-diagrams/ball-variables/bann.html` instead of `viewer/taylor/summary-taylor-diagrams/all-variables/ann.html`.