### PR TITLE
Remove bad formatting warning

### DIFF
--- a/output_viewer/htmlbuilder.py
+++ b/output_viewer/htmlbuilder.py
@@ -95,7 +95,7 @@ class HTMLBuilder(object):
                         parser.feed(child)
                         proxy.cleanup()
                     except Exception as e:
-                        print("Bad formatting", e)
+                        #print("Bad formatting", e)
                         root.data(str(child))
                 else:
                     root.data(str(child))


### PR DESCRIPTION
Remove bad formatting warning. Resolves https://github.com/E3SM-Project/e3sm_diags/issues/342. 

https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.XMLParser states "Changed in version 3.8: Parameters are now keyword-only. The html argument no longer supported." 

The `output_viewer` defaults to an `except` block in this case and the viewer still appears to render correctly. Therefore, for now, we'll simply comment out the bad formatting warning.